### PR TITLE
refactor: Add MessagesProvider to manage chat messages state

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import { ChatRoom } from "./components/ChatRoom";
 import { Header } from "./components/Header";
+import { MessagesProvider } from "./context/MessagesProvider";
 import { ModelProvider } from "./context/ModelProvider";
 import { ThemeProvider } from "./context/ThemeProvider";
 
@@ -7,8 +8,10 @@ function App() {
   return (
     <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
       <ModelProvider defaultModel="llama3-70b-8192" storageKey="vite-ui-model">
-        <Header />
-        <ChatRoom />
+        <MessagesProvider>
+          <Header />
+          <ChatRoom />
+        </MessagesProvider>
       </ModelProvider>
     </ThemeProvider>
   );

--- a/src/context/MessagesProvider.jsx
+++ b/src/context/MessagesProvider.jsx
@@ -1,0 +1,58 @@
+/* eslint-disable react/prop-types */
+import { createContext, useContext, useReducer } from "react";
+
+const MessagesContext = createContext();
+
+export const MessagesProvider = ({ children }) => {
+  // messages initial state
+  const messagesInitialState = [];
+
+  // messages reducer function to manage messages state
+  const messagesReducer = (state, action) => {
+    switch (action.type) {
+      case "SEND_MESSAGE":
+        return [
+          ...state,
+          {
+            role: "user",
+            content: action.payload,
+          },
+          {
+            role: "assistant",
+            content: "",
+          },
+        ];
+      case "RECEIVE_MESSAGE":
+        return state.map((message, index) =>
+          index === state.length - 1 && message.role === "assistant"
+            ? { ...message, content: message.content + action.payload }
+            : message
+        );
+      case "DELETE_MESSAGES":
+        return [];
+      default:
+        return state;
+    }
+  };
+
+  // messages reducer hook
+  const [messages, dispatch] = useReducer(
+    messagesReducer,
+    messagesInitialState
+  );
+
+  return (
+    <MessagesContext.Provider value={{ messages, dispatch }}>
+      {children}
+    </MessagesContext.Provider>
+  );
+};
+
+// messages custom hook
+export const useMessages = () => {
+  const context = useContext(MessagesContext);
+  if (!context) {
+    throw new Error("useMessages must be used within a MessagesProvider");
+  }
+  return context;
+};


### PR DESCRIPTION
**Description**
- Wrap the `Header` and `ChatRoom` components with the `MessagesProvider` context
- Update the `ChatRoom` component to use the `useMessages` hook from the `MessagesProvider` context
- Modify the `handleSend` function to dispatch actions to update the chat messages state