### PR TITLE
**feat: Add tooltips to button components using @radix-ui/react-tooltip**

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@radix-ui/react-icons": "^1.3.0",
         "@radix-ui/react-label": "^2.1.0",
         "@radix-ui/react-slot": "^1.1.0",
+        "@radix-ui/react-tooltip": "^1.1.2",
         "@uiw/react-md-editor": "^4.0.4",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
@@ -1472,6 +1473,40 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.1.2.tgz",
+      "integrity": "sha512-9XRsLwe6Yb9B/tlnYCPVUd/TFS4J7HuOZW345DCeC6vKIxQGMZdx21RK4VoZauPD5frgkXTYVS5y90L+3YBn4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-popper": "1.2.0",
+        "@radix-ui/react-portal": "1.1.1",
+        "@radix-ui/react-presence": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-slot": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-visually-hidden": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
@@ -1570,6 +1605,29 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.1.0.tgz",
+      "integrity": "sha512-N8MDZqtgCgG5S3aV60INAB475osJousYpZ4cTJ2cFbMpdHS5Y6loLTH8LPtkj2QN0x93J30HT/M3qJXM0+lyeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-slot": "^1.1.0",
+    "@radix-ui/react-tooltip": "^1.1.2",
     "@uiw/react-md-editor": "^4.0.4",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/src/components/ChatInput.jsx
+++ b/src/components/ChatInput.jsx
@@ -125,6 +125,7 @@ export const ChatInput = ({
           />
           {isGenerating ? (
             <Button
+              title="Stop"
               size="icon"
               className="rounded-full p-0 w-10 h-10 disabled:opacity-30 bg-primary text-primary-foreground disabled:pointer-events-none disabled:bg-primary disabled:text-primary-foreground"
               type="button"
@@ -134,6 +135,7 @@ export const ChatInput = ({
             </Button>
           ) : (
             <Button
+              title="Send"
               size="icon"
               className="rounded-full p-0 w-10 h-10 disabled:opacity-30 bg-accent text-accent-foreground disabled:pointer-events-none disabled:bg-primary disabled:text-primary-foreground"
               type="submit"

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -44,7 +44,12 @@ export const Header = ({ setIsGenerating }) => {
           <ThemeToggler />
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="outline" size="icon" className="rounded-full">
+              <Button
+                title="Menu"
+                variant="outline"
+                size="icon"
+                className="rounded-full"
+              >
                 <PersonIcon width="18" height="18" />
               </Button>
             </DropdownMenuTrigger>

--- a/src/components/Message.jsx
+++ b/src/components/Message.jsx
@@ -48,6 +48,7 @@ export const Message = ({
       {role === "user" ? (
         <div className="flex max-w-lg self-end group">
           <Button
+            title="Edit Text"
             onClick={() => handleEditMessage(content)}
             variant="ghost"
             size="icon"
@@ -97,6 +98,7 @@ export const Message = ({
               }`}
             >
               <Button
+                title="Copy"
                 variant="ghost"
                 size="icon"
                 className="size-8"
@@ -105,6 +107,7 @@ export const Message = ({
                 <CopyIcon className="inline-block text-primary/70 size-[18px]" />
               </Button>
               <Button
+                title="Regenerate Response"
                 variant="ghost"
                 size="icon"
                 className="size-8"
@@ -114,7 +117,12 @@ export const Message = ({
               </Button>
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <Button variant="ghost" size="icon" className="size-8">
+                  <Button
+                    title="Modify Response"
+                    variant="ghost"
+                    size="icon"
+                    className="size-8"
+                  >
                     <MixerHorizontalIcon className="inline-block text-primary/70 size-[18px]" />
                   </Button>
                 </DropdownMenuTrigger>

--- a/src/components/ThemeToggler.jsx
+++ b/src/components/ThemeToggler.jsx
@@ -17,6 +17,7 @@ export function ThemeToggler() {
   };
   return (
     <Button
+      title="Toggle theme"
       variant="outline"
       size="icon"
       className="rounded-full"

--- a/src/components/ui/button.jsx
+++ b/src/components/ui/button.jsx
@@ -5,6 +5,13 @@ import { cva } from "class-variance-authority";
 
 import { cn } from "@/utils/shadUtils";
 
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  TooltipProvider,
+} from "./tooltip";
+
 const buttonVariants = cva(
   "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50",
   {
@@ -34,14 +41,26 @@ const buttonVariants = cva(
 );
 
 const Button = React.forwardRef(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
+  ({ className, title, variant, size, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : "button";
-    return (
+    const btnElement = (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
         {...props}
       />
+    );
+    return title ? (
+      <TooltipProvider delayDuration={100}>
+        <Tooltip>
+          <TooltipTrigger asChild>{btnElement}</TooltipTrigger>
+          <TooltipContent className="bg-primary-foreground text-primary rounded-md text-xs border border-border capitalize">
+            {title}
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    ) : (
+      btnElement
     );
   }
 );

--- a/src/components/ui/tooltip.jsx
+++ b/src/components/ui/tooltip.jsx
@@ -1,0 +1,29 @@
+/* eslint-disable react/prop-types */
+import * as React from "react";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+
+import { cn } from "@/utils/shadUtils";
+
+const TooltipProvider = TooltipPrimitive.Provider;
+
+const Tooltip = TooltipPrimitive.Root;
+
+const TooltipTrigger = TooltipPrimitive.Trigger;
+
+const TooltipContent = React.forwardRef(
+  ({ className, sideOffset = 5, ...props }, ref) => (
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      side="bottom"
+      className={cn(
+        "z-50 overflow-hidden rounded-md bg-primary px-2 py-1 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };


### PR DESCRIPTION
- Install `@radix-ui/react-tooltip` package
- Integrate tooltip as a title for button components
- Update all button elements to include a title attribute for better accessibility and user experience